### PR TITLE
Use channel when parsing files

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ func main() {
 		log.Fatal("Must set environment variable EOD_DATA_DIR")
 	}
 
-	currentDay := Day(2023, 8, 8)
+	currentDay := Day(2023, 8, 9)
 	marketDayCount := 65
 	strategies := []Strategy{
 		&MonthClimb{},

--- a/parser.go
+++ b/parser.go
@@ -17,36 +17,26 @@ type EODData struct {
 	Volume float64
 }
 
-type ParsedEODData struct {
-	data [][]*EODData
-	err  error
-}
-
 const header = "Symbol,Date,Open,High,Low,Close,Volume"
 
-func ParseEODFiles(dataDir string, exchange string, dates []time.Time) ParsedEODData {
+func ParseEODFiles(dataDir string, exchange string, dates []time.Time) ([][]*EODData, error) {
 	eodData := make([][]*EODData, len(dates))
-	var err error
 
 	for i, date := range dates {
 		rawData, err := LoadEODFile(dataDir, exchange, date)
 		if err != nil {
-			break
+			return nil, err
 		}
 
 		data, err := ParseEODFileContents(rawData)
 		if err != nil {
-			break
+			return nil, err
 		}
 
 		eodData[i] = data
 	}
 
-	if err != nil {
-		return ParsedEODData{err: err}
-	}
-
-	return ParsedEODData{data: eodData}
+	return eodData, nil
 }
 
 func ParseEODFileContents(rawData []string) ([]*EODData, error) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -138,7 +138,7 @@ func TestParseMinimalEODFile(t *testing.T) {
 	}
 
 	for i, c := range cases {
-		actual, err := ParseEODFile(c.rawData)
+		actual, err := ParseEODFileContents(c.rawData)
 
 		if actual == nil {
 			if c.expected != nil {

--- a/scanner.go
+++ b/scanner.go
@@ -37,8 +37,7 @@ func Scan(currentDay time.Time, marketDayCount int, dataDir string, strategies [
 	exchange := "NASDAQ"
 	eodData := make([][]*EODData, marketDayCount)
 
-	for i := len(dates) - 1; i >= 0; i-- {
-		date := dates[i]
+	for i, date := range dates {
 		rawData, err := LoadEODFile(dataDir, exchange, date)
 		if err != nil {
 			return nil, err

--- a/scanner.go
+++ b/scanner.go
@@ -30,9 +30,14 @@ func (s *ScanResult) Sort() {
 
 }
 
-func parse(dataDir string, exchange string, dates []time.Time, c chan ParsedEODData) {
-	result := ParseEODFiles(dataDir, exchange, dates)
-	c <- result
+type parsedEODData struct {
+	data [][]*EODData
+	err  error
+}
+
+func parse(dataDir string, exchange string, dates []time.Time, c chan parsedEODData) {
+	data, err := ParseEODFiles(dataDir, exchange, dates)
+	c <- parsedEODData{data: data, err: err}
 }
 
 func Scan(currentDay time.Time, marketDayCount int, dataDir string, strategies []Strategy) ([]*ScanResult, error) {
@@ -41,7 +46,7 @@ func Scan(currentDay time.Time, marketDayCount int, dataDir string, strategies [
 	exchange := "NASDAQ"
 	eodData := make([][]*EODData, 0, marketDayCount)
 	dateBatches := batch(dates)
-	parseChan := make(chan ParsedEODData, len(dateBatches))
+	parseChan := make(chan parsedEODData, len(dateBatches))
 
 	for _, dateBatch := range dateBatches {
 		go parse(dataDir, exchange, dateBatch, parseChan)

--- a/util.go
+++ b/util.go
@@ -1,5 +1,28 @@
 package main
 
+import (
+	"runtime"
+)
+
+func batch[T any](elems []T) [][]T {
+	batchSize := len(elems) / runtime.NumCPU()
+	batches := make([][]T, (len(elems)+batchSize-1)/batchSize)
+	prev := 0
+	i := 0
+	till := len(elems) - batchSize
+
+	for prev < till {
+		next := prev + batchSize
+		batches[i] = elems[prev:next]
+		prev = next
+		i++
+	}
+
+	batches[i] = elems[prev:]
+
+	return batches
+}
+
 func max(a float64, b float64) float64 {
 	if a > b {
 		return a


### PR DESCRIPTION
Batch files by NumCPU() and go parse. Cuts runtime ~50%. Also some minor cleanup.