### PR TITLE
Sma prof

### DIFF
--- a/indicators.go
+++ b/indicators.go
@@ -68,15 +68,17 @@ type SMA struct {
 	cumulative float64
 	cb         []float64
 	i          int
+	pf         float64
 }
 
 func (s *SMA) Init(periods int) {
 	s.Periods = periods
 	s.cb = make([]float64, periods, periods)
+	s.pf = float64(periods)
 }
 
 func (s *SMA) Add(new float64) {
-	s.cumulative += new - s.cb[s.i%s.Periods]
+	s.cumulative += new - s.cb[s.i]
 	s.cb[s.i] = new
 	s.i++
 
@@ -84,7 +86,7 @@ func (s *SMA) Add(new float64) {
 		s.i = 0
 	}
 
-	s.Value = s.cumulative / float64(s.Periods)
+	s.Value = s.cumulative / s.pf
 }
 
 //

--- a/indicators.go
+++ b/indicators.go
@@ -66,23 +66,23 @@ type SMA struct {
 	Periods    int
 	Value      float64
 	cumulative float64
-	ring       *ring.Ring
+	cb         []float64
+	i          int
 }
 
 func (s *SMA) Init(periods int) {
 	s.Periods = periods
-	s.ring = ring.New(periods)
+	s.cb = make([]float64, periods, periods)
 }
 
 func (s *SMA) Add(new float64) {
-	s.cumulative += new
+	s.cumulative += new - s.cb[s.i%s.Periods]
+	s.cb[s.i] = new
+	s.i++
 
-	if s.ring.Value != nil {
-		s.cumulative -= s.ring.Value.(float64)
+	if s.i == s.Periods {
+		s.i = 0
 	}
-
-	s.ring.Value = new
-	s.ring = s.ring.Next()
 
 	s.Value = s.cumulative / float64(s.Periods)
 }


### PR DESCRIPTION
Before:

```
~/projects/github/jbirddog/eod_scanner | go 1.21.0 | sma_prof > go tool pprof eod_scanner eod_scanner.prof 
File: eod_scanner
Type: cpu
Time: Oct 23, 2023 at 4:02pm (EDT)
Duration: 402.08ms, Total samples = 500ms (124.35%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top 10
Showing nodes accounting for 270ms, 54.00% of 500ms total
Showing top 10 nodes out of 100
      flat  flat%   sum%        cum   cum%
      70ms 14.00% 14.00%       90ms 18.00%  main.(*SMA).Add
      40ms  8.00% 22.00%       40ms  8.00%  strconv.readFloat
      30ms  6.00% 28.00%       30ms  6.00%  runtime.findObject
      30ms  6.00% 34.00%       60ms 12.00%  runtime.scanobject
      20ms  4.00% 38.00%       80ms 16.00%  runtime.gcDrain
      20ms  4.00% 42.00%      120ms 24.00%  runtime.mallocgc
      20ms  4.00% 46.00%       20ms  4.00%  runtime.procyield
      20ms  4.00% 50.00%       20ms  4.00%  runtime.writeHeapBits.flush
      10ms  2.00% 52.00%       10ms  2.00%  container/ring.(*Ring).Next
      10ms  2.00% 54.00%       20ms  4.00%  container/ring.New
(pprof) 

----
0.43u 0.06s 0.20r 83924kB ./eod_scanner -config .config.json
----
```

After:

```
File: eod_scanner
Type: cpu
Time: Oct 23, 2023 at 4:52pm (EDT)
Duration: 301.04ms, Total samples = 390ms (129.55%)
Entering interactive mode (type "help" for commands, "o" for options)
(pprof) top 10
Showing nodes accounting for 190ms, 48.72% of 390ms total
Showing top 10 nodes out of 99
      flat  flat%   sum%        cum   cum%
      50ms 12.82% 12.82%       50ms 12.82%  strconv.readFloat
      20ms  5.13% 17.95%       20ms  5.13%  internal/bytealg.IndexByteString
      20ms  5.13% 23.08%       20ms  5.13%  main.(*SMA).Add
      20ms  5.13% 28.21%       60ms 15.38%  runtime.gcDrain
      20ms  5.13% 33.33%       40ms 10.26%  strings.Index
      20ms  5.13% 38.46%       20ms  5.13%  time.daysSinceEpoch (inline)
      10ms  2.56% 41.03%       10ms  2.56%  aeshashbody
      10ms  2.56% 43.59%       10ms  2.56%  bufio.(*Scanner).advance
      10ms  2.56% 46.15%       10ms  2.56%  container/ring.(*Ring).Next
      10ms  2.56% 48.72%       40ms 10.26%  main.(*EODExchStdCSVParser).parseDate
(pprof) 

----
0.31u 0.06s 0.13r 75060kB ./eod_scanner -config .config.json
----

```